### PR TITLE
PKG-7239 initial release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+upload_without_merge: True
+upload_to_staging_channel_in_pr: False
+channels: [cuda12_def]
+# don't skip existing, to allow build and copy-over to the buildout channel
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,4 @@ channels: [cuda12_def]
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+aggregate_check: false


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7239](https://anaconda.atlassian.net/browse/PKG-7239) 
- [Upstream repository](https://github.com/conda-forge/arm-variant-feedstock)

### Explanation of changes:

- Please note the usefulness of keeping this as close to conda-forge as possible. Smaller diffs make it easier to sync and easier to update the whole stack in general.
- Pulls recipe from conda-forge
- Upload to buildout channel for now
- this is used in many of the cuda recipes. Currently we comment it out in the feedstocks. Pulling this in allows us to reduce the diff and speed up syncing/deployment, leading to better update cadence
- note that uploads (not builds) fail for non-linux-64, because noarch_upload is set to linux-64 only. Skipping other platforms would lead to bigger diffs with upstream, making it less rapid to sync - I'd rather avoid this.


[PKG-7239]: https://anaconda.atlassian.net/browse/PKG-7239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ